### PR TITLE
Consider policy violation related metrics in deciding build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Setting these options will force the task to wait for the BOM analysis to be fin
 | Medium Vulnerability Count | thresholdMedium | Maximum number of medium vulnerabilities to tolerate. A value of `-1` disables this threshold. | False |
 | Low Vulnerability Count | thresholdLow | Maximum number of low vulnerabilities to tolerate. A value of `-1` disables this threshold. | False |
 | Unassigned Vulnerability Count | thresholdUnassigned | Maximum number of unassigned vulnerabilities to tolerate. A value of `-1` disables this threshold. | False |
+| Fail Policy Violation Count | thresholdpolicyViolationsFail | Maximum number of failed policy violations to tolerate. A value of `-1` disables this threshold. | False |
+| Warn Policy Violation Count | thresholdpolicyViolationsWarn | Maximum number of warn policy violations to tolerate. A value of `-1` disables this threshold. | False |
+| Info Policy Violation Count | thresholdpolicyViolationsInfo | Maximum number of info policy violations to tolerate. A value of `-1` disables this threshold. | False |
+| Total Policy Violation Count | thresholdpolicyViolationsTotal | Maximum number of Total policy violations to tolerate. A value of `-1` disables this threshold. | False |
 
 ### SSL Options
 | Name    | Id |      Description      |  Required |

--- a/UploadBOM/src/task.js
+++ b/UploadBOM/src/task.js
@@ -30,6 +30,7 @@ async function validateThresholdsAsync(token, thresholdAction, thresholdExpert, 
     const metrics = await dtrackManager.waitMetricsRefresh();
 
     console.log(localize('VulnCount', metrics.critical, metrics.high, metrics.medium, metrics.low, metrics.unassigned, metrics.suppressed));
+    console.log(localize('PolicyViolationCount', metrics.policyViolationsFail,metrics.policyViolationsWarn,metrics.policyViolationsInfo,metrics.policyViolationsTotal));
 
     try {
       thresholdExpert.validateThresholds(metrics)
@@ -59,6 +60,11 @@ const run = async () => {
   const thresholdLow = tl.getInput('thresholdLow', false) || -1;
   const thresholdUnassigned = tl.getInput('thresholdUnassigned', false) || -1;
 
+  const thresholdpolicyViolationsFail = tl.getInput('thresholdpolicyViolationsFail', false) || -1;
+  const thresholdpolicyViolationsWarn = tl.getInput('thresholdpolicyViolationsWarn', false) || -1;
+  const thresholdpolicyViolationsInfo = tl.getInput('thresholdpolicyViolationsInfo', false) || -1;
+  const thresholdpolicyViolationsTotal = tl.getInput('thresholdpolicyViolationsTotal', false) || -1;
+
   let caFile;
   if (tl.stats(caFilePath).isFile() ) {
     console.log(localize('ReadingCA', caFilePath));
@@ -80,7 +86,11 @@ const run = async () => {
     Number.parseInt(thresholdHigh), 
     Number.parseInt(thresholdMedium), 
     Number.parseInt(thresholdLow), 
-    Number.parseInt(thresholdUnassigned));
+    Number.parseInt(thresholdUnassigned),
+    Number.parseInt(thresholdpolicyViolationsFail),
+    Number.parseInt(thresholdpolicyViolationsWarn),
+    Number.parseInt(thresholdpolicyViolationsInfo),
+    Number.parseInt(thresholdpolicyViolationsTotal));
   await validateThresholdsAsync(token, thresholdAction, thresholdExpert, dtrackManager);
 };
 

--- a/UploadBOM/src/task.json
+++ b/UploadBOM/src/task.json
@@ -124,6 +124,42 @@
       "groupName": "thresholds",
       "helpMarkDown": "Maximum number of unassigned vulnerabilities to tolerate.\nA value of -1 disables this threshold."
     },
+     {
+      "name": "thresholdpolicyViolationsFail",
+      "label": "Fail Policy Violation Count",
+      "type": "string",
+      "defaultValue": "-1",
+      "required": false,
+      "groupName": "thresholds",
+      "helpMarkDown": "Maximum number of failed policy violations to tolerate.\nA value of -1 disables this threshold."
+    },
+     {
+      "name": "thresholdpolicyViolationsWarn",
+      "label": "Warn Policy Violation Count",
+      "type": "string",
+      "defaultValue": "-1",
+      "required": false,
+      "groupName": "thresholds",
+      "helpMarkDown": "Maximum number of warn policy violations to tolerate.\nA value of -1 disables this threshold."
+    },
+     {
+      "name": "thresholdpolicyViolationsInfo",
+      "label": "Info Policy Violation Count",
+      "type": "string",
+      "defaultValue": "-1",
+      "required": false,
+      "groupName": "thresholds",
+      "helpMarkDown": "Maximum number of info policy violations to tolerate.\nA value of -1 disables this threshold."
+    },
+     {
+      "name": "thresholdpolicyViolationsTotal",
+      "label": "Total Policy Violation Count",
+      "type": "string",
+      "defaultValue": "-1",
+      "required": false,
+      "groupName": "thresholds",
+      "helpMarkDown": "Maximum number of Total policy violations to tolerate.\nA value of -1 disables this threshold."
+    },
     {
       "name": "caFilePath",
       "label": "Trusted CA certificate",
@@ -156,7 +192,8 @@
     "High": "High",
     "Medium": "Medium",
     "Low": "Low",
-    "Unassigned": "Unassigned"
+    "Unassigned": "Unassigned",
+    "PolicyViolationCount": "Current Policy Violation Count:\nFail: %s\nWarn:%s\nInfo: %s\nTotal: %s"    
   },
   "execution": {
     "Node10": {

--- a/UploadBOM/src/thresholdExpert.js
+++ b/UploadBOM/src/thresholdExpert.js
@@ -1,7 +1,15 @@
 import { localize } from "./localization";
 
 class ThresholdExpert {
-  constructor(criticalCount, highCount, mediumCount, lowCount, unassignedCount) {
+  constructor(criticalCount, 
+    highCount, 
+    mediumCount, 
+    lowCount, 
+    unassignedCount,
+    policyViolationsFail,
+    policyViolationsWarn,
+    policyViolationsInfo,
+    policyViolationsTotal) {
     if (!Number.isInteger(criticalCount)) {
       throw new Error(localize('ThresholdInNotAnInteger', localize('Critical')));
     }
@@ -22,11 +30,31 @@ class ThresholdExpert {
       throw new Error(localize('ThresholdInNotAnInteger', localize('Unassigned')));
     }
 
+     if (!Number.isInteger(policyViolationsFail)) {
+      throw new Error(localize('ThresholdInNotAnInteger', localize('policyViolationsFail')));
+    }
+
+     if (!Number.isInteger(policyViolationsWarn)) {
+      throw new Error(localize('ThresholdInNotAnInteger', localize('policyViolationsWarn')));
+    }
+
+     if (!Number.isInteger(policyViolationsInfo)) {
+      throw new Error(localize('ThresholdInNotAnInteger', localize('policyViolationsInfo')));
+    }
+
+     if (!Number.isInteger(policyViolationsTotal)) {
+      throw new Error(localize('ThresholdInNotAnInteger', localize('policyViolationsTotal')));
+    }
+
     this.criticalCount = criticalCount;
     this.highCount = highCount;
     this.mediumCount = mediumCount;
     this.lowCount = lowCount;
     this.unassignedCount = unassignedCount;
+    this.policyViolationsFail = policyViolationsFail;
+    this.policyViolationsWarn = policyViolationsWarn;
+    this.policyViolationsInfo = policyViolationsInfo;
+    this.policyViolationsTotal = policyViolationsTotal;
   }
 
   areThresholdsValidated() {
@@ -34,7 +62,11 @@ class ThresholdExpert {
       this.highCount >= 0 ||
       this.mediumCount >= 0 ||
       this.lowCount >= 0 ||
-      this.unassignedCount >= 0;
+      this.unassignedCount >= 0 ||
+      this.policyViolationsFail >= 0 ||
+      this.policyViolationsWarn >= 0 ||
+      this.policyViolationsInfo >= 0 ||
+      this.policyViolationsTotal >= 0;
   }
 
   validateThresholds(metrics) {
@@ -56,6 +88,22 @@ class ThresholdExpert {
 
     if (this.unassignedCount >= 0 && metrics.unassigned > this.unassignedCount) {
       throw new Error(localize('VulnCountThresholdSurpassed', localize('Unassigned')));
+    }   
+
+     if (this.policyViolationsFail >= 0 && metrics.policyViolationsFail > this.policyViolationsFail) {
+      throw new Error(localize('VulnCountThresholdSurpassed', localize('policyViolationsFail')));
+    }
+
+     if (this.policyViolationsWarn >= 0 && metrics.policyViolationsWarn > this.policyViolationsWarn) {
+      throw new Error(localize('VulnCountThresholdSurpassed', localize('policyViolationsWarn')));
+    }
+
+     if (this.policyViolationsInfo >= 0 && metrics.policyViolationsInfo > this.policyViolationsInfo) {
+      throw new Error(localize('VulnCountThresholdSurpassed', localize('policyViolationsInfo')));
+    }
+
+     if (this.policyViolationsTotal >= 0 && metrics.policyViolationsTotal > this.policyViolationsTotal) {
+      throw new Error(localize('VulnCountThresholdSurpassed', localize('policyViolationsTotal')));
     }
   }
 }


### PR DESCRIPTION
@Zargath 
Current plugin does not include following policy violation metrics in deciding build failure. Adding that support.

1.     policyViolationsFail
2.     policyViolationsWarn
3.     policyViolationsInfo
4.     policyViolationsTotal

We have requirement of considering policy failures as build failures. This change has kept behavior current version same and added functionality on top/in sync with existing code flow.

Please review and let me know if this can be included. 
