### PR TITLE
added preliminary support for project name/version

### DIFF
--- a/UploadBOM/src/dtrackClient.js
+++ b/UploadBOM/src/dtrackClient.js
@@ -33,6 +33,29 @@ class DTrackClient {
         });
     });
   }
+  
+  getProjectUUID(projectName, projectVersion) {
+    return new Promise((resolve, reject) => {
+            request(`/api/v1/project/lookup/name=${projectName}&version=${projectVersion}`, {
+        ...this.baseOptions,
+        method: 'GET',
+      },
+      (error, response) => {
+        if (!error && response.statusCode == 200) {
+
+          let projectUUID = ''
+
+          if(response.body){
+            projectUUID = response.body.uuid;
+          }
+
+          resolve(projectUUID)
+        }
+        reject({ error, response });
+      });
+    });
+  }
+
 
   pullProcessingStatusAsync(token) {
     return new Promise((resolve, reject) => {

--- a/UploadBOM/src/dtrackManager.js
+++ b/UploadBOM/src/dtrackManager.js
@@ -11,6 +11,14 @@ class DTrackManager {
     return info;
   }
 
+  async getProjectUUID(projectName, projectVersion){
+    const projectUUID = await this.dtrackClient.getProjectUUID(projectName, projectVersion);
+    return projectUUID;
+  }
+  catch (err) {
+    throw new Error(localize('GetProjectUUIDFailed', this.getErrorMessage(err)))
+  }
+
   async uploadBomAsync(bom) {
     try {
       const token = await this.dtrackClient.uploadBomAsync(this.projectId, bom);

--- a/UploadBOM/src/task.js
+++ b/UploadBOM/src/task.js
@@ -49,7 +49,9 @@ const run = async () => {
   tl.setResourcePath(path.join(__dirname, 'task.json'));
 
   const bomFilePath = tl.getPathInput('bomFilePath', true, true);
-  const dtrackProjId = tl.getInput('dtrackProjId', true);
+  const dtrackProjId = tl.getInput('dtrackProjId', false);
+  const dtrackProjName = tl.getInput('dtrackProjName', false);
+  const dtrackProjVer = tl.getInput('dtrackProjVer', false);
   const dtrackAPIKey = tl.getInput('dtrackAPIKey', true);
   const dtrackURI = tl.getInput('dtrackURI', true);
   const caFilePath = tl.getPathInput('caFilePath', false, true);
@@ -73,7 +75,12 @@ const run = async () => {
   }
 
   const client = new DTrackClient(dtrackURI, dtrackAPIKey, caFile);
-  const dtrackManager = new DTrackManager(client, dtrackProjId);
+  let dtrackManager = new DTrackManager(client, dtrackProjId);
+
+  if (dtrackProjId == null) {
+    dtrackProjId = dtrackManager.getProjectUUID()
+    dtrackManager = new DTrackManager(client, dtrackProjId)
+  } 
 
   console.log(localize('ReadingBom', bomFilePath));
   const bom = loadFile(bomFilePath, 'UnableToReadBom');


### PR DESCRIPTION
I have zero experience with TS and minimal (and years old) JS experience so realistically this is more of a conversation starter than a real PR.

Our org does not hard code project uuids anywhere so I was hoping to add support for project name/version which is then used to fetch the project uuid in subsequent calls. Some of the constructs (dtrackManager) don't seem to be flexibly built to support calls without a projectId, but I hope this works ok.